### PR TITLE
Update angular-pageslide-directive.js

### DIFF
--- a/src/angular-pageslide-directive.js
+++ b/src/angular-pageslide-directive.js
@@ -237,6 +237,14 @@ angular.module("pageslide-directive", [])
                         psClose(slider, param);
                     }
                 });
+                
+                $scope.$watch("psSize", function(newValue, oldValue) {
+                    if (oldValue !== newValue) {
+                        // when the psSize attribute is changed, resize the pageslide
+                        param.size = newValue;
+                        psOpen(slider, param);
+                    }
+                });
 
 
                 /*


### PR DESCRIPTION
psSize is not watched, we use the pageSlide for a number of slides, not all have the same size. A $watch on the size would enable resizing of the pageSlide
